### PR TITLE
Add conditional check for textareas

### DIFF
--- a/app/controls/details/views/init.ejs
+++ b/app/controls/details/views/init.ejs
@@ -65,7 +65,7 @@
 
         <% list( model.attr('partyDetailsTypes'), function( types, title ) { %>
             <legend><%= pretifyString( title, true ) %></legend>
-            <% 
+            <%
                 list( types, function( traveller, i ) {
                     var agesForThisType = ages[ traveller.attr('type') + 'Ages' ];
                     var disabled = {};
@@ -121,7 +121,7 @@
         <fieldset <%== notes.show ? '' : 'style="display:none;"' %>>
             <legend><%= notes.title %></legend>
             <div><%== notes.helptext %></div>
-            <input name="notes" data-label="" placeholder="<%= notes.placeholder %>" type="textarea" />
+            <input name="notes" data-label="" placeholder="<%= notes.placeholder %>" type="textarea" data-type="textarea" />
         </fieldset>
 
         <fieldset>

--- a/app/controls/form/form.js
+++ b/app/controls/form/form.js
@@ -150,9 +150,18 @@ define([
         'formElement': function( index, el ) {
             var $el = can.$(el),
                 attr = $el.attr('name'),
-                // default to text input
-                type = $el.attr('type') || 'text',
-                wrapper = views[ type + 'Wrapper' ] || views.wrapper,
+                // Default to text input
+                type = $el.attr('type') || 'text';
+
+            // Fixes IE returning the wrong value for type attributes.
+            // For input fields with the type set to "textarea", "text" is being returned.
+            // This conditional handles it by checking the "data-type" attribute also.
+            if($el.attr('type') === 'text' &&
+                $el.data('type') === 'textarea') {
+                type = 'textarea';
+            }
+
+            var wrapper = views[ type + 'Wrapper' ] || views.wrapper,
                 options;
 
             options = can.extend(true, {


### PR DESCRIPTION
IE was reading the type of inputs with type='textarea' as type='text'. This commit fixes this by checking for this occurence in conjunction with a data-type set to textarea which it can use as a fallback

Demonstration of the the bug which affects IE from Edge downwards:
http://imgur.com/a/dq0YY