### PR TITLE
Set the default placeholder to nothing and start the index for pets f…

### DIFF
--- a/app/controls/details/details.js
+++ b/app/controls/details/details.js
@@ -177,7 +177,7 @@ define([
                 var numberOfPets = booking.attr('propertyData').attr('numberOfPets') || 5;
                 var petRange = [];
 
-                for (var i = 1; i <= numberOfPets; i++) {
+                for (var i = 0; i <= numberOfPets; i++) {
                     petRange.push(new can.List([i.toString(), i.toString()]));
                 }
 

--- a/app/controls/details/views/init.ejs
+++ b/app/controls/details/views/init.ejs
@@ -116,7 +116,7 @@
         <fieldset <%== model.attr('canBookExtras') ? '' : 'style="display:none;"' %>>
             <legend>Extras</legend>
             <input name="price.extras" type="mixedCheckboxSelect" data-value-attr="code" data-text-attr="description" />
-            <input name="pets" type="<%= petsType %>" data-min="0" data-label="Pets" />
+            <input name="pets" type="<%= petsType %>" data-placeholder="" data-label="Pets" />
         </fieldset>
 
         <fieldset <%== notes.show ? '' : 'style="display:none;"' %>>


### PR DESCRIPTION
…rom 0

This behaviour has been requested by the only brand which implements the pets field as a select not a number input. (the one who I originally implemented this behaviour for in the first place)